### PR TITLE
feat(executor): add the allow-empty-input option of stylelint

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ See: https://nx.dev/l/n/core-concepts/configuration#targets
 
 ### Options
 
+#### `allowEmptyInput`
+
+The executor exits without throwing an error when 'lintFilePatterns' match no files.
+
+Type: `boolean`
+
+Default: `true`
+
 #### `config`
 
 Path of the stylelint configuration file.

--- a/packages/nx-stylelint/src/executors/lint/executor.spec.ts
+++ b/packages/nx-stylelint/src/executors/lint/executor.spec.ts
@@ -7,6 +7,7 @@ import { normalize } from 'path';
 import executor from './executor';
 
 const defaultOptions: LintExecutorSchema = {
+  allowEmptyInput: true,
   config: '.stylelintrc.json',
   lintFilePatterns: ['styles.scss'],
   formatter: 'string',
@@ -121,6 +122,7 @@ describe('nx-stylelint:lint executor', () => {
 
     expect(success).toBeTruthy();
     expect(mockLint).toHaveBeenCalledWith({
+      allowEmptyInput: true,
       configFile: '.stylelintrc.json',
       files: ['styles.scss'],
       reportNeedlessDisables: true,

--- a/packages/nx-stylelint/src/executors/lint/executor.ts
+++ b/packages/nx-stylelint/src/executors/lint/executor.ts
@@ -41,6 +41,7 @@ export async function lintExecutor(
     formatter: validFormatter ? options.formatter : defaultFormatter,
     fix: options.fix,
     maxWarnings: options.maxWarnings ? options.maxWarnings : undefined,
+    allowEmptyInput: options.allowEmptyInput
   };
 
   const result: LinterResult = await stylelint.lint(stylelintOptions);

--- a/packages/nx-stylelint/src/executors/lint/schema.d.ts
+++ b/packages/nx-stylelint/src/executors/lint/schema.d.ts
@@ -1,6 +1,7 @@
 import type { FormatterType } from 'stylelint';
 
 export interface LintExecutorSchema {
+  allowEmptyInput: boolean;
   config?: string;
   fix: boolean;
   force: boolean;

--- a/packages/nx-stylelint/src/executors/lint/schema.json
+++ b/packages/nx-stylelint/src/executors/lint/schema.json
@@ -5,6 +5,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "allowEmptyInput": {
+      "type": "boolean",
+      "description": "The executor exits without throwing an error when 'lintFilePatterns' match no files.",
+      "default": true
+    },
     "config": {
       "type": "string",
       "description": "Path of the stylelint configuration file."


### PR DESCRIPTION
If stylelint is setup on a library that doesn't yet have css/scss the linting will fail. Passing this flag allows it to succeed even if no files are found.