### PR TITLE
chore(generators): export generators from index.ts

### DIFF
--- a/packages/nx-stylelint/src/index.ts
+++ b/packages/nx-stylelint/src/index.ts
@@ -1,0 +1,3 @@
+export * from './generators/configuration/generator';
+export * from './generators/init/generator';
+export * from './generators/scss/generator';


### PR DESCRIPTION
Hi there. Thx a lot for this great library.

We are currently creating a nx workspace with a couple of custom generators. In our generators we are currently calling your generators. Since the generators are not exported in the `index.ts` we need to use a deep import which is not so nice.

This PR  exports the generators from `index.ts` to make them publicly available so we can import them nicely. 