### PR TITLE
fix(executor): accept unplanned positional arguments

### DIFF
--- a/packages/nx-stylelint/src/executors/lint/schema.json
+++ b/packages/nx-stylelint/src/executors/lint/schema.json
@@ -3,7 +3,6 @@
   "cli": "nx",
   "title": "Stylelint Lint Target",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "allowEmptyInput": {
       "type": "boolean",


### PR DESCRIPTION
When using `stylelint` target with `lint-stagged`, the command will be appended with the file name as a positional argument e.g.
```
nx affected --target=stylelint --fix --base=main --head=HEAD path/to/my/file
```

This breaks the linting, since passing explicit `"additionalProperties": false` means no positional arguments will be accepted.
Removing this property, allows us to simply ignore any unplanned positional arguments.