### PR TITLE
Move @nrwl/devkit to peerDependencies

### DIFF
--- a/packages/nx-stylelint/package.json
+++ b/packages/nx-stylelint/package.json
@@ -28,10 +28,10 @@
   "schematics": "./generators.json",
   "builders": "./executors.json",
   "dependencies": {
-    "@nrwl/devkit": ">=15.0.0",
     "tslib": "^2.5.0"
   },
   "peerDependencies": {
+    "@nrwl/devkit": ">=15.0.0",
     "stylelint": "^15.0.0",
     "stylelint-config-standard": ">=30.0.0",
     "stylelint-config-standard-scss": ">=7.0.0"


### PR DESCRIPTION
Declaring `@nrwl/devkit` as a dependency with a range (`>=15.0.0`) causes NX projects that depend on `nx-stylelint` to potentially pull in a higher version of `@nrwl/devkit` than the version of NX used.