### PR TITLE
Fix addScssToStylelintConfiguration checking the files instead of ext…

### DIFF
--- a/nx-stylelint/src/generators/init/generator.ts
+++ b/nx-stylelint/src/generators/init/generator.ts
@@ -142,7 +142,7 @@ function addScssToStylelintConfiguration(tree: Tree) {
         (item) =>
           (item.files === '**/*.scss' || (Array.isArray(item.files) && item.files.includes('**/*.scss'))) &&
           (item.extends === 'stylelint-config-standard-scss' ||
-            (Array.isArray(item.files) && item.files.includes('stylelint-config-standard-scss')))
+            (Array.isArray(item.extends) && item.extends.includes('stylelint-config-standard-scss')))
       )
     )
       return value;


### PR DESCRIPTION
…ends.

E.g., it still duplicates the scss when we have:

```
    {
      "files": ["**/*.scss"],
      "extends": ["stylelint-config-standard-scss"],
      "rules": {}
    }
```