### PR TITLE
Fix/stylelint esm default import

### DIFF
--- a/nx-stylelint/src/executors/lint/executor.spec.ts
+++ b/nx-stylelint/src/executors/lint/executor.spec.ts
@@ -10,6 +10,7 @@ jest.mock('node:fs', () => ({
   ...jest.requireActual('node:fs'),
   existsSync: jest.fn(),
   writeFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
 }));
 
 let mockResult: LinterResult;

--- a/nx-stylelint/src/utils/stylelint.ts
+++ b/nx-stylelint/src/utils/stylelint.ts
@@ -1,5 +1,5 @@
 import type { lint } from 'stylelint';
 
 export async function loadStylelintLint(): Promise<typeof lint> {
-  return (await import('stylelint')).lint;
+  return (await import('stylelint')).default.lint;
 }


### PR DESCRIPTION
fixes https://github.com/Phillip9587/nx-stylelint/issues/880

## Summary                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                 
  Fix `TypeError: stylelint is not a function` in the lint executor when run against `stylelint@^17`.                                                                                                                                                                                                              
   
  Stylelint 17 ships as pure ESM with a single `default` export (the postcss plugin function, with `lint` attached as a property). The previous loader read `.lint` directly off the dynamic-import namespace, which is `undefined` for this shape — the executor then crashed before linting any file.            
                                                         
  ## Changes                                                                                                                                                                                                                                                                                                       
                                                         
  - `src/utils/stylelint.ts`: load lint via the default export.                                                                                                                                                                                                                                                    
    ```ts
    return (await import('stylelint')).default.lint;                                                                                                                                                                                                                                                               
  - src/executors/lint/executor.spec.ts: also mock mkdirSync so the output-file test does not hit the real filesystem.                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                   
  Why default.lint over a fallback chain                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                   
  The peer dependency is pinned to stylelint ^17, and every 17.x release uses the same ESM shape. A defensive mod.lint ?? mod.default?.lint ?? mod.default chain would silently fall through to mod.default (the postcss plugin, not the lint function) if the shape ever changes, producing confusing downstream  
  errors instead of failing loudly at the load site. Direct default.lint matches reality and fails fast if the shape ever moves.                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
